### PR TITLE
Fix linter errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,16 +33,18 @@ Pirate Weather Translations is a Python library that translates machine-readable
   ```python
   from pirateweather_translations.translation import Translation
   from pirateweather_translations.lang.en import template
+
   t = Translation(template)
-  result = t.translate(['title', 'heavy-rain'])  # Returns "Heavy Rain"
+  result = t.translate(["title", "heavy-rain"])  # Returns "Heavy Rain"
   ```
 - Test dynamic loading:
   ```python
   from pirateweather_translations.dynamic_loader import load_translation
   from pirateweather_translations.translation import Translation
-  template = load_translation('en')
+
+  template = load_translation("en")
   t = Translation(template)
-  result = t.translate(['title', 'clear'])  # Returns "Clear"
+  result = t.translate(["title", "clear"])  # Returns "Clear"
   ```
 
 ## Validation

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,7 @@
 
 ignore = [
     "F601", # Duplicate literal
+    "N999", # Invalid module name
 ]
 
 [lint.flake8-pytest-style]

--- a/pirateweather_translations/dynamic_loader.py
+++ b/pirateweather_translations/dynamic_loader.py
@@ -1,6 +1,8 @@
-import os
 import importlib
+import os
+
 import pirateweather_translations.lang
+
 from .translation import Translation
 
 

--- a/pirateweather_translations/lang/cs.py
+++ b/pirateweather_translations/lang/cs.py
@@ -73,17 +73,13 @@ def until_starting_again_function(stack, condition, a, b):
     starting = ""
     if condition.endswith("srážky"):
         starting = ", které začnou znovu "
-    elif (
-        condition.endswith(("déšť", "déšť se sněhem", "vítr"))
-    ):
+    elif condition.endswith(("déšť", "déšť se sněhem", "vítr")):
         starting = ", který začne znovu "
     elif condition.endswith(("sněžení", "mrholení")):
         starting = ", které začne znovu "
     elif condition.endswith("vlhkost"):
         starting = ", která začne znovu "
-    elif (
-        condition.endswith(("zataženo", "mlhavo", "oblačno"))
-    ):
+    elif condition.endswith(("zataženo", "mlhavo", "oblačno")):
         starting = "a začne znovu "
 
     return condition + " až do " + remove_prefix_and_use_genitive(a) + starting + b
@@ -97,17 +93,13 @@ def starting_continuing_until_function(stack, condition, a, b):
     continuing = ""
     if condition.endswith("srážky"):
         continuing = ", které přetrvají až do "
-    elif (
-        condition.endswith(("déšť", "déšť se sněhem", "vítr"))
-    ):
+    elif condition.endswith(("déšť", "déšť se sněhem", "vítr")):
         continuing = ", který přetrvá až do "
     elif condition.endswith(("sněžení", "mrholení")):
         continuing = ", které přetrvá až do "
     elif condition.endswith("vlhkost"):
         continuing = ", která přetrvá až do "
-    elif (
-        condition.endswith(("zataženo", "mlhavo", "oblačno"))
-    ):
+    elif condition.endswith(("zataženo", "mlhavo", "oblačno")):
         continuing = " a přetrvá až do "
     return (
         "od "

--- a/pirateweather_translations/lang/cs.py
+++ b/pirateweather_translations/lang/cs.py
@@ -74,19 +74,15 @@ def until_starting_again_function(stack, condition, a, b):
     if condition.endswith("srážky"):
         starting = ", které začnou znovu "
     elif (
-        condition.endswith("déšť")
-        or condition.endswith("déšť se sněhem")
-        or condition.endswith("vítr")
+        condition.endswith(("déšť", "déšť se sněhem", "vítr"))
     ):
         starting = ", který začne znovu "
-    elif condition.endswith("sněžení") or condition.endswith("mrholení"):
+    elif condition.endswith(("sněžení", "mrholení")):
         starting = ", které začne znovu "
     elif condition.endswith("vlhkost"):
         starting = ", která začne znovu "
     elif (
-        condition.endswith("zataženo")
-        or condition.endswith("mlhavo")
-        or condition.endswith("oblačno")
+        condition.endswith(("zataženo", "mlhavo", "oblačno"))
     ):
         starting = "a začne znovu "
 
@@ -102,19 +98,15 @@ def starting_continuing_until_function(stack, condition, a, b):
     if condition.endswith("srážky"):
         continuing = ", které přetrvají až do "
     elif (
-        condition.endswith("déšť")
-        or condition.endswith("déšť se sněhem")
-        or condition.endswith("vítr")
+        condition.endswith(("déšť", "déšť se sněhem", "vítr"))
     ):
         continuing = ", který přetrvá až do "
-    elif condition.endswith("snežení") or condition.endswith("mrholení"):
+    elif condition.endswith(("sněžení", "mrholení")):
         continuing = ", které přetrvá až do "
     elif condition.endswith("vlhkost"):
         continuing = ", která přetrvá až do "
     elif (
-        condition.endswith("zataženo")
-        or condition.endswith("mlhavo")
-        or condition.endswith("oblačno")
+        condition.endswith(("zataženo", "mlhavo", "oblačno"))
     ):
         continuing = " a přetrvá až do "
     return (

--- a/pirateweather_translations/lang/eo.py
+++ b/pirateweather_translations/lang/eo.py
@@ -20,10 +20,7 @@ def make_accusative(a):
     """
     words = a.split(" ")
     accusative_words = [
-        w + "n"
-        if (w.endswith(("j","o","a")) and w != "la")
-        else w
-        for w in words
+        w + "n" if (w.endswith(("j", "o", "a")) and w != "la") else w for w in words
     ]
     return " ".join(accusative_words)
 

--- a/pirateweather_translations/lang/eo.py
+++ b/pirateweather_translations/lang/eo.py
@@ -21,7 +21,7 @@ def make_accusative(a):
     words = a.split(" ")
     accusative_words = [
         w + "n"
-        if w.endswith("j") or w.endswith("o") or (w.endswith("a") and w != "la")
+        if (w.endswith(("j","o","a")) and w != "la")
         else w
         for w in words
     ]

--- a/pirateweather_translations/lang/he.py
+++ b/pirateweather_translations/lang/he.py
@@ -25,9 +25,7 @@ SATURDAY = "שבת"
 
 
 def proper_at_time_prefix(at):
-    if (
-        at.startswith((SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY))
-    ):
+    if at.startswith((SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY)):
         return "ב"
     # default, return no prefix
     return ""

--- a/pirateweather_translations/lang/he.py
+++ b/pirateweather_translations/lang/he.py
@@ -26,13 +26,7 @@ SATURDAY = "שבת"
 
 def proper_at_time_prefix(at):
     if (
-        at.startswith(SUNDAY)
-        or at.startswith(MONDAY)
-        or at.startswith(TUESDAY)
-        or at.startswith(WEDNESDAY)
-        or at.startswith(THURSDAY)
-        or at.startswith(FRIDAY)
-        or at.startswith(SATURDAY)
+        at.startswith((SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY))
     ):
         return "ב"
     # default, return no prefix

--- a/pirateweather_translations/lang/ko.py
+++ b/pirateweather_translations/lang/ko.py
@@ -14,7 +14,7 @@ def join_with_shared_prefix(a, b, joiner):
 
 
 def and_function(stack, a, b):
-    joiner = ", " if "," in a else ", "
+    joiner = ", "
     return join_with_shared_prefix(a, b, joiner)
 
 

--- a/pirateweather_translations/lang/no.py
+++ b/pirateweather_translations/lang/no.py
@@ -27,7 +27,7 @@ def and_function(stack, a, b):
     """
     Combines two strings with a shared prefix and an appropriate joiner.
     """
-    joiner = " og " if "," not in a else " og "
+    joiner = " og "
     return join_with_shared_prefix(a, b, joiner)
 
 

--- a/pirateweather_translations/lang/ro.py
+++ b/pirateweather_translations/lang/ro.py
@@ -19,7 +19,7 @@ def join_with_shared_prefix(a, b, joiner):
 
 
 def and_function(stack, a, b):
-    return join_with_shared_prefix(a, b, " și " if "," in a else " și ")
+    return join_with_shared_prefix(a, b, " și ")
 
 
 def through_function(stack, a, b):

--- a/pirateweather_translations/lang/sk.py
+++ b/pirateweather_translations/lang/sk.py
@@ -134,16 +134,14 @@ def until_starting_again_function(stack, condition, a, b):
     if condition.endswith("zrážky"):
         starting = ", ktoré začnú znovu "
     elif (
-        condition.endswith("dážď")
-        or condition.endswith("dážď so snehom")
-        or condition.endswith("vietor")
+        condition.endswith(("dážď", "dážď so snehom", "vietor"))
     ):
         starting = ", ktorý začne znovu "
-    elif condition.endswith("sneženie") or condition.endswith("mrholenie"):
+    elif condition.endswith(("sneženie", "mrholenie")):
         starting = ", ktoré začne znovu "
     elif condition.endswith("vlhkosť"):
         starting = ", ktorá začne znovu "
-    elif condition.endswith("zamračené") or condition.endswith("hmlisto"):
+    elif condition.endswith(("zamračené", "hmlisto")):
         starting = "a začne znovu "
 
     return condition + " až do " + remove_prefix_and_use_genitive(a) + starting + b
@@ -155,16 +153,14 @@ def starting_continuing_until_function(stack, condition, a, b):
     if condition.endswith("zrážky"):
         continuing = ", ktoré pretrvajú až do "
     elif (
-        condition.endswith("dážď")
-        or condition.endswith("dážď so snehom")
-        or condition.endswith("vietor")
+        condition.endswith(("dážď", "dážď so snehom", "vietor"))
     ):
         continuing = ", ktorý pretrvá až do "
-    elif condition.endswith("sneženie") or condition.endswith("mrholenie"):
+    elif condition.endswith(("sneženie", "mrholenie")):
         continuing = ", ktoré pretrvá až do "
     elif condition.endswith("vlhkosť"):
         continuing = ", ktorá pretrvá až do "
-    elif condition.endswith("zamračené") or condition.endswith("hmlisto"):
+    elif condition.endswith(("zamračené", "hmlisto")):
         continuing = " a pretrvá až do "
 
     return f"od {remove_prefix_and_use_genitive(a)} {condition}{continuing}{remove_prefix_and_use_genitive(b)}"

--- a/pirateweather_translations/lang/sk.py
+++ b/pirateweather_translations/lang/sk.py
@@ -133,9 +133,7 @@ def until_starting_again_function(stack, condition, a, b):
 
     if condition.endswith("zrážky"):
         starting = ", ktoré začnú znovu "
-    elif (
-        condition.endswith(("dážď", "dážď so snehom", "vietor"))
-    ):
+    elif condition.endswith(("dážď", "dážď so snehom", "vietor")):
         starting = ", ktorý začne znovu "
     elif condition.endswith(("sneženie", "mrholenie")):
         starting = ", ktoré začne znovu "
@@ -152,9 +150,7 @@ def starting_continuing_until_function(stack, condition, a, b):
 
     if condition.endswith("zrážky"):
         continuing = ", ktoré pretrvajú až do "
-    elif (
-        condition.endswith(("dážď", "dážď so snehom", "vietor"))
-    ):
+    elif condition.endswith(("dážď", "dážď so snehom", "vietor")):
         continuing = ", ktorý pretrvá až do "
     elif condition.endswith(("sneženie", "mrholenie")):
         continuing = ", ktoré pretrvá až do "

--- a/pirateweather_translations/lang/sv.py
+++ b/pirateweather_translations/lang/sv.py
@@ -78,7 +78,7 @@ def and_function(stack, a, b):
     - str: The two strings joined together with the appropriate joiner.
     """
     # Determine the joiner based on whether a contains a comma
-    joiner = " och " if "," in a else " och "
+    joiner = " och "
 
     # Use the join_with_shared_prefix function to join the two strings
     return join_with_shared_prefix(a, b, joiner)

--- a/pirateweather_translations/translation.py
+++ b/pirateweather_translations/translation.py
@@ -39,7 +39,7 @@ def parse(template, expr, stack):
             result = val(stack)
 
         else:
-            raise ValueError(f'"{expr}" is not a valid language template pattern.')
+            raise TypeError(f'"{expr}" is not a valid language template pattern.')
 
         stack.pop()
         return result
@@ -120,7 +120,7 @@ def parse(template, expr, stack):
             result = val(stack, *parsed_args)
 
         else:
-            raise ValueError(f'"{expr[0]}" is not a valid language template pattern.')
+            raise TypeError(f'"{expr[0]}" is not a valid language template pattern.')
 
         stack.pop()
         return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ruff==0.16.0
 pytest==9.1.1
-pytest-subtests==0.15.0
 coverage==7.15.2
 pytest-cov==7.1.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     package_data={
         "pirateweather_translations.lang": ["*.py"],  # Include all .py files in lang/
     },
-    long_description=open("README.md").read(),
+    long_description=README,
     long_description_content_type="text/markdown",
 )

--- a/test.py
+++ b/test.py
@@ -1,7 +1,9 @@
-import pytest
+import importlib.util
 import os
 import re
-import importlib.util
+
+import pytest
+
 from pirateweather_translations.translation import Translation
 
 
@@ -134,7 +136,7 @@ def test_languages(subtests):
 
                 # `template` must be defined inside the Python module
                 if not hasattr(mod, "cases"):  # pragma: no cover
-                    raise Exception(f"No 'cases' found in {lang_name}.py")
+                    raise AssertionError(f"No 'cases' found in {lang_name}.py")
 
                 template = mod.cases
 


### PR DESCRIPTION
## Describe the change
The linter was throwing some errors which needed to be fixed so I went and fixed any errors that it was throwing.

## Type of change

- [ ] New translation
- [ ] Translation update
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- Link to documentation pull request in the API repo:
- [x] Tests have been added for the new language
- [x] Tests pasts locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been linted (`python3 -m ruff check . --fix`)
- [x] Code has been formatted using the ruff formatter (`python3 -m ruff format .`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Czech handling for accented snowfall terms.
  - Standardized conjunction formatting in Korean, Norwegian, Romanian, and Swedish translations.
  - Invalid translation template patterns now report the appropriate error type.

- **Refactor**
  - Simplified language-specific grammar and condition handling without changing intended translation behavior.
  - Improved package metadata and validation behavior.

- **Documentation**
  - Updated translation examples and formatting for consistency.

- **Maintenance**
  - Refined linting and test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->